### PR TITLE
Add support for single csv/json data file

### DIFF
--- a/C#_Solution/README.md
+++ b/C#_Solution/README.md
@@ -9,7 +9,7 @@ After the custom export app runs the DescriptiveDataUploadApp, a console pops up
 
 1.	App (client) ID. Find this ID in the registered app information on the Azure portal under **Application (client) ID**. If you haven’t created and registered your app yet, follow the instructions in our main data import documentation, under Register a new app in Azure.
 
-2.	Path to the zip folder. Format the path like this: `C:\\Users\\JaneDoe\\OneDrive - Microsoft\\Desktop\\info.zip`.
+2.	Path to the zip folder or the single csv/json data file. Format the path like this: `C:\\Users\\JaneDoe\\OneDrive - Microsoft\\Desktop\\info.zip`.
 
 3.	Azure Active Directory tenant ID. Also find this ID on the app's overview page under **Directory (tenant) ID**.
 

--- a/PowerShell_Solution/README.md
+++ b/PowerShell_Solution/README.md
@@ -17,7 +17,7 @@ or go to https://www.powershellgallery.com/packages/MSAL.PS for instructions on 
 
 Mandatory parameters 
 1.	App (client) ID. Find this ID in the registered app information on the Azure portal under **Application (client) ID**. If you haven’t created and registered your app yet, follow the instructions in our main data import documentation, under Register a new app in Azure.
-2.	Path to the zip folder. Format the path like this: `C:\\Users\\JaneDoe\\OneDrive - Microsoft\\Desktop\\info.zip`. If you haven't downloaded the zip folder yet, find it [here](https://go.microsoft.com/fwlink/?linkid=2243005). Refer to our [main data-import documentation](https://learn.microsoft.com/viva/insights/advanced/admin/import-org-data-first#prepare-the-data-export) for more information about using the files in this folder. Or, for importing survey results, download [this zip folder](https://go.microsoft.com/fwlink/?linkid=2242706) and refer to our [documentation](https://learn.microsoft.com/viva/insights/advanced/admin/import-survey-results).
+2.	Path to the zip folder or the single csv/json data file. Format the path like this: `C:\\Users\\JaneDoe\\OneDrive - Microsoft\\Desktop\\info.zip`. If you haven't downloaded the zip folder yet, find it [here](https://go.microsoft.com/fwlink/?linkid=2243005). Refer to our [main data-import documentation](https://learn.microsoft.com/viva/insights/advanced/admin/import-org-data-first#prepare-the-data-export) for more information about using the files in this folder. Or, for importing survey results, download [this zip folder](https://go.microsoft.com/fwlink/?linkid=2242706) and refer to our [documentation](https://learn.microsoft.com/viva/insights/advanced/admin/import-survey-results).
 3.	Azure Active Directory tenant ID. Also find this ID on the app's overview page under **Directory (tenant) ID**.
 4.	Ingress Data Type: `HR` or `Survey`
 
@@ -34,9 +34,9 @@ Go to the specific folder
 
 Run the script with parameters in PowerShell terminal 
 
-1. ``` .\DescriptiveDataUpload.ps1 -ClientId **** -pathToZippedFile  "C:\repos\temp\info.zip" -TenantId ***** -ingressDataType HR -ClientSecret **** ```
+1. ``` .\DescriptiveDataUpload.ps1 -ClientId **** -pathToFile  "C:\repos\temp\info.zip" -TenantId ***** -ingressDataType HR -ClientSecret **** ```
 
-2. ``` .\DescriptiveDataUpload.ps1 -ClientId **** -pathToZippedFile  "C:\repos\temp\info.zip" -TenantId ***** -ingressDataType Survey -certificateName CN=ypochampally-certificate```
+2. ``` .\DescriptiveDataUpload.ps1 -ClientId **** -pathToFile  "C:\repos\temp\info.zip" -TenantId ***** -ingressDataType Survey -certificateName CN=ypochampally-certificate```
 
 ## API that the script runs 
 
@@ -59,7 +59,7 @@ Sample response:
 
 **Possible errors in the API**
 1. Missing header <Authorization>: Response status 403 
-2. Missing zip file: Response status 500
+2. Missing file: Response status 500
 3. Expired Authorization header: Response status 200, but the response will suggest to sign in again 
 4. If the meta.json and data.csv have incorrect data (i.e mismatch in the fieldnames/number of fields, empty fields, etc ): the response status will be 200, but the ingestion will be stuck in "ValidationFailed" state
 


### PR DESCRIPTION
## Test screenshot:
### Running C# app
**Single csv data file**
<img width="967" height="491" alt="C#_csv" src="https://github.com/user-attachments/assets/6df215ec-3bbe-4d6f-b62f-4255cc8e83a5" />
**Single json data file**
<img width="976" height="510" alt="image" src="https://github.com/user-attachments/assets/b299d9fe-ac4c-477d-be77-1c3ba8c6ce91" />

### Running powershell script:
**.csv**
<img width="1095" height="1002" alt="image" src="https://github.com/user-attachments/assets/a62a6d42-33b1-46fc-af93-843a57a9ea37" />
**.json**
<img width="1085" height="965" alt="image" src="https://github.com/user-attachments/assets/4472ecdf-d616-4a18-b96f-399a693f54e1" />

All uploads showing in ingestion history on VI:
<img width="1265" height="481" alt="image" src="https://github.com/user-attachments/assets/3adaa48a-deca-41ce-be83-27dc64379984" />